### PR TITLE
Xml node collation bug fixes

### DIFF
--- a/src/Xml/NodeStrategyCollation.php
+++ b/src/Xml/NodeStrategyCollation.php
@@ -40,6 +40,7 @@ class NodeStrategyCollation extends NodeStrategy
             do {
                 $node->attributes[$xmlReader->name] = $xmlReader->value;
             } while ($xmlReader->moveToNextAttribute());
+            $xmlReader->moveToElement();
         }
 
         $children = [];

--- a/src/Xml/NodeStrategyCollation.php
+++ b/src/Xml/NodeStrategyCollation.php
@@ -45,12 +45,13 @@ class NodeStrategyCollation extends NodeStrategy
 
         $children = [];
 
-        $scanner = new NodeStrategyTraversal();
-        $scanner->addNodeHandler("*", new self(function ($node) use (&$children) {
-            $children[] = $node;
-        }));
-
-        $scanner->parse($xmlReader, $startingDepth);
+        if (!$xmlReader->isEmptyElement) {
+            $scanner = new NodeStrategyTraversal();
+            $scanner->addNodeHandler("*", new self(function ($node) use (&$children) {
+                $children[] = $node;
+            }));
+            $scanner->parse($xmlReader, $startingDepth);
+        }
 
         $node->children = $children;
 

--- a/src/Xml/NodeStrategyCollation.php
+++ b/src/Xml/NodeStrategyCollation.php
@@ -36,7 +36,7 @@ class NodeStrategyCollation extends NodeStrategy
         $node->depth = $xmlReader->depth;
         $node->text = $xmlReader->readString();
 
-        if ($xmlReader->moveToFirstAttribute()) {
+        if ($xmlReader->hasAttributes && $xmlReader->moveToFirstAttribute()) {
             do {
                 $node->attributes[$xmlReader->name] = $xmlReader->value;
             } while ($xmlReader->moveToNextAttribute());


### PR DESCRIPTION
After much hunting I think i've finally located and fixed this issue the right way.

there were a number of issues in the collation strategy which resulted in the next element after an empty element being skipped.

Firstly, the attribute reader was not pointing the reader back to the element once it had read the attributes, so we couldn't use `isEmptyElement` properly before trying to read children.

Secondly, we were't testing for `isEmptyElement` before attempting to read children. After an empty element was read, the next element read() would be read by the empty element's child scanner which had the wrong depth level restriction for the next element (as it wasn't a child of the empty element).