### PR TITLE
NULL safe model state

### DIFF
--- a/src/Modelling/ModelState.php
+++ b/src/Modelling/ModelState.php
@@ -325,11 +325,19 @@ class ModelState implements \ArrayAccess, JsonSerializable
          * so we're not using that any more.
          * */
         foreach ($this->modelData as $key => $modelDataValue) {
-            if (
-                (!isset($this->changeSnapshotData[$key]) && $modelDataValue) ||
-                (isset($this->changeSnapshotData[$key]) && $this->changeSnapshotData[$key] != $modelDataValue)
-            ) {
-                $differences[$key] = $modelDataValue;
+
+            if (!isset( $this->changeSnapshotData[ $key ] )) {
+                if ($modelDataValue === null) {
+                    // Value is NULL so isset will have failed. Setting a previously unset key to NULL is treated as no change
+                    continue;
+                }
+
+                // Key added
+                $differences[ $key ] = $modelDataValue;
+            }
+            elseif ($modelDataValue !== null && $this->changeSnapshotData[ $key ] != $modelDataValue) {
+                // Key changed
+                $differences[ $key ] = $modelDataValue;
             }
         }
         return $differences;

--- a/src/Modelling/ModelState.php
+++ b/src/Modelling/ModelState.php
@@ -266,15 +266,29 @@ class ModelState implements \ArrayAccess, JsonSerializable
     public function hasChanged()
     {
         foreach ($this->modelData as $key => $value) {
-            if (!isset($this->changeSnapshotData[$key]) || $this->changeSnapshotData[$key] != $value) {
-                // Something was added or changed.
+            if (!isset( $this->changeSnapshotData[ $key ] )) {
+                if ($value === null) {
+                    // Value is NULL so isset will have failed. Setting a previously unset key to NULL is treated as no change
+                    continue;
+                }
+
+                // Key added
+                return true;
+            }
+            if ($this->changeSnapshotData[ $key ] != $value) {
+                // Key changed
                 return true;
             }
         }
 
         foreach ($this->changeSnapshotData as $key => $value) {
-            if (!isset($this->modelData[$key])) {
-                // Something was removed.
+            if (!isset( $this->modelData[ $key ] )) {
+                if ($value === null) {
+                    // Isset fails for NULL values. Setting a key to NULL is treated the same as un-setting it
+                    continue;
+                }
+
+                // Key removed.
                 return true;
             }
         }

--- a/tests/Modelling/ModelStateTest.php
+++ b/tests/Modelling/ModelStateTest.php
@@ -128,6 +128,7 @@ class ModelStateTest extends RhubarbTestCase
 
         $model->A = 1;
         $model->B = 2;
+        $model->C = null;
 
         $this->assertEquals(["A" => 1, "B" => 2], $model->getModelChanges());
 
@@ -138,6 +139,30 @@ class ModelStateTest extends RhubarbTestCase
         $model->A = 2;
 
         $this->assertEquals(["A" => 2], $model->getModelChanges());
+
+        $model->takeChangeSnapshot();
+
+        $model->C = 3;
+
+        $this->assertEquals(["C" => 3], $model->getModelChanges());
+
+        $model->takeChangeSnapshot();
+
+        $model->C = null;
+
+        $this->assertEquals([], $model->getModelChanges());
+
+        $model->takeChangeSnapshot();
+
+        $model->C = 3;
+
+        $this->assertEquals(["C" => 3], $model->getModelChanges());
+
+        $model->takeChangeSnapshot();
+
+        unset( $model->C );
+
+        $this->assertEquals([], $model->getModelChanges());
     }
 
     public function testSupportsGetters()

--- a/tests/Modelling/ModelStateTest.php
+++ b/tests/Modelling/ModelStateTest.php
@@ -44,7 +44,28 @@ class ModelStateTest extends RhubarbTestCase
 
         $model->takeChangeSnapshot();
 
+        $model->NewProperty = null;
+
+        $this->assertTrue($model->hasChanged());
+
+        $model->takeChangeSnapshot();
+
+        // Check when a property is set to null when it's already null - null safety
+        $model->NewProperty = null;
+
+        $this->assertFalse($model->hasChanged());
+
         unset($model->NewProperty);
+
+        $this->assertFalse($model->hasChanged());
+
+        $model->NewProperty = 'abc';
+
+        $this->assertTrue($model->hasChanged());
+
+        $model->takeChangeSnapshot();
+
+        unset( $model->NewProperty );
 
         $this->assertTrue($model->hasChanged());
     }

--- a/tests/Modelling/ModelStateTest.php
+++ b/tests/Modelling/ModelStateTest.php
@@ -55,6 +55,7 @@ class ModelStateTest extends RhubarbTestCase
 
         $this->assertFalse($model->hasChanged());
 
+        // un-setting a null should result in no change
         unset($model->NewProperty);
 
         $this->assertFalse($model->hasChanged());
@@ -64,7 +65,7 @@ class ModelStateTest extends RhubarbTestCase
         $this->assertTrue($model->hasChanged());
 
         $model->takeChangeSnapshot();
-
+        // un-setting some other value is a change
         unset( $model->NewProperty );
 
         $this->assertTrue($model->hasChanged());
@@ -118,6 +119,33 @@ class ModelStateTest extends RhubarbTestCase
         $model->NewProperty = "12323";
 
         $this->assertTrue($model->hasPropertyChanged("NewProperty"));
+
+        $model->takeChangeSnapshot();
+
+        $model->NewProperty = null;
+
+        $this->assertTrue($model->hasPropertyChanged("NewProperty"));
+
+        $model->takeChangeSnapshot();
+
+        // Setting null to null should result in no change
+        $model->NewProperty = null;
+
+        $this->assertFalse($model->hasPropertyChanged("NewProperty"));
+
+        $model->NewProperty = "12323";
+        $this->assertTrue($model->hasPropertyChanged("NewProperty"));
+
+        $model->takeChangeSnapshot();
+
+        unset( $model->NewProperty );
+
+        $this->assertTrue($model->hasPropertyChanged("NewProperty"));
+
+        $model->takeChangeSnapshot();
+
+        $model->NewProperty = "12323";
+        $this->assertTrue($model->hasPropertyChanged("NewProperty"));
     }
 
     public function testGetModelChanges()
@@ -142,27 +170,28 @@ class ModelStateTest extends RhubarbTestCase
 
         $model->takeChangeSnapshot();
 
-        $model->C = 3;
-
-        $this->assertEquals(["C" => 3], $model->getModelChanges());
-
-        $model->takeChangeSnapshot();
-
+        // Ensure that setting a value that is not set to null results in no change
         $model->C = null;
 
         $this->assertEquals([], $model->getModelChanges());
 
+        $model->C = 3;
+        $model->takeChangeSnapshot();
+
+        // Remove C by setting to null
+        $model->C = null;
+
+        $this->assertEquals(['C' => null], $model->getModelChanges());
+
         $model->takeChangeSnapshot();
 
         $model->C = 3;
-
-        $this->assertEquals(["C" => 3], $model->getModelChanges());
-
         $model->takeChangeSnapshot();
 
+        // Remove C via unset
         unset( $model->C );
 
-        $this->assertEquals([], $model->getModelChanges());
+        $this->assertEquals(['C' => null], $model->getModelChanges());
     }
 
     public function testSupportsGetters()


### PR DESCRIPTION
WIll not detect a change if a previously unset or `null` value is set to `null` or is unset.

also includes nulled/unset properties in the array changes