### PR TITLE
JsonResponse freedom

### DIFF
--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -18,8 +18,6 @@
 
 namespace Rhubarb\Crown\Response;
 
-use Rhubarb\Crown\Modelling\ModelState;
-
 require_once __DIR__ . "/Response.php";
 
 /**
@@ -39,14 +37,6 @@ class JsonResponse extends Response
 
     public function formatContent()
     {
-        $object = $this->getContent();
-
-        if (is_array($object) || $object instanceof ModelState || $object instanceof \stdClass) {
-            $jsonString = json_encode($object, JSON_PRETTY_PRINT);
-
-            return $jsonString;
-        }
-
-        return false;
+        return json_encode($this->getContent());
     }
 }


### PR DESCRIPTION
Removed checks to allow all response types to be serialised as JSON, so custom objects can be handled rather than just stdClass objects.

Also removed JSON_PRETTY_PRINT setting so responses are more compressed and the tests pass again.