### PR TITLE
Adding update to fix matching of a URL when it starts with an Integer

### DIFF
--- a/src/UrlHandlers/CollectionUrlHandling.php
+++ b/src/UrlHandlers/CollectionUrlHandling.php
@@ -53,7 +53,7 @@ trait CollectionUrlHandling
 
         $this->matchedUrl = $this->url;
 
-        if (preg_match("|^" . $this->url . "/?([[:digit:]]+)/?|", $uri, $match)) {
+        if (preg_match("`^" . $this->url . "/?([0-9]+)(/|$)`", $uri, $match) && isset($match[1])) {
             $this->resourceIdentifier = $match[1];
             $this->isCollection = false;
 


### PR DESCRIPTION
The following PR adds a solution to enable a URL with the below Pattern to be routed correctly. Please see example URL below:

http://<domain>/donate/one-off/5k-a-Day/