### PR TITLE
XHR error trapping

### DIFF
--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -18,6 +18,7 @@
 
 namespace Rhubarb\Crown\UrlHandlers;
 
+use Rhubarb\Crown\Application;
 use Rhubarb\Crown\PhpContext;
 use Rhubarb\Crown\Exceptions\ForceResponseException;
 use Rhubarb\Crown\Exceptions\RhubarbException;
@@ -330,7 +331,14 @@ abstract class UrlHandler implements GeneratesResponseInterface
 
     public function generateResponseForException(RhubarbException $er)
     {
-        $response = new HtmlResponse();
+        $context = Application::current()->context();
+
+        if ($context->isXhrRequest()) {
+            $response = new Response();
+        } else {
+            $response = new HtmlResponse();
+        }
+
         $response->setResponseCode(Response::HTTP_STATUS_SERVER_ERROR_GENERIC);
         $response->setContent($er->getPublicMessage());
 


### PR DESCRIPTION
Making default exception trapping just return the error message without HTML layout when responding to an XhrRequest.