### PR TITLE
Extend UnitTestingEmailProvider

### DIFF
--- a/tests/Fixtures/UnitTestingEmailProvider.php
+++ b/tests/Fixtures/UnitTestingEmailProvider.php
@@ -24,13 +24,13 @@ use Rhubarb\Crown\Sendables\Sendable;
 class UnitTestingEmailProvider extends EmailProvider
 {
     /**
-     * @var Email
+     * @var array
      */
-    private static $_lastEmail;
+    private static $_emailHistory;
 
     public function send(Sendable $email)
     {
-        self::$_lastEmail = $email;
+        self::$_emailHistory [] = $email;
     }
 
     /**
@@ -38,6 +38,14 @@ class UnitTestingEmailProvider extends EmailProvider
      */
     public static function getLastEmail()
     {
-        return self::$_lastEmail;
+        return self::$_emailHistory[count($_emailHistory) - 1];
+    }
+
+    /**
+     * @return array
+     */
+    public static function getEmailHistory()
+    {
+        return self::$_emailHistory;
     }
 }

--- a/tests/Fixtures/UnitTestingEmailProvider.php
+++ b/tests/Fixtures/UnitTestingEmailProvider.php
@@ -38,7 +38,7 @@ class UnitTestingEmailProvider extends EmailProvider
      */
     public static function getLastEmail()
     {
-        return self::$_emailHistory[count($_emailHistory) - 1];
+        return self::$_emailHistory[count(self::$_emailHistory) - 1];
     }
 
     /**


### PR DESCRIPTION
Changed functionality of UnitTestingEmailProvider to store the history of emails it has sent to allow for unit tests to access more than just the last email sent.