### PR TITLE
add version to Modules and general information logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### 1.6.2
+
+* Added:    Information logging level
+* Added:    Module version
+
 ### 1.6.1
 
 * Added:    Added pre-response filtering

--- a/src/Logging/Log.php
+++ b/src/Logging/Log.php
@@ -65,6 +65,11 @@ abstract class Log
      */
     const PERFORMANCE_LEVEL = 32;
 
+    /**
+     * Use to log general information - not as noisy as debug, but important to be logged somewhere.
+     */
+    const INFORMATION_LEVEL = 64;
+
     const ALL = 255;
 
     /**
@@ -259,6 +264,11 @@ abstract class Log
     public static function performance($message, $category = "", $additionalData = [])
     {
         self::createEntry(self::PERFORMANCE_LEVEL, $message, $category, $additionalData);
+    }
+
+    public static function info($message, $category = "", $additionalData = [])
+    {
+        self::createEntry(self::INFORMATION_LEVEL, $message, $category, $additionalData);
     }
 
     public static function bulkData($message, $category = "", $data = "")

--- a/src/Module.php
+++ b/src/Module.php
@@ -67,6 +67,11 @@ abstract class Module
      */
     protected $urlHandlersRegistered = false;
 
+    /**
+     * @var int $version
+     */
+    protected $version;
+
     public function __construct()
     {
         $this->moduleName = str_ireplace("Module", "", get_class($this));
@@ -196,5 +201,14 @@ abstract class Module
     public function getCustardCommands()
     {
         return [];
+    }
+
+    /**
+     * Used to retrieve the module Version.
+     *
+     * @return int
+     */
+    public function getVersion(): int {
+        return $this->version;
     }
 }


### PR DESCRIPTION
for task: https://app.asana.com/0/511589261340481/770719260861879/f

Adds:
- generic 'Information' logging level
- a version variable to modules, used in the Migrations Module to get the current Application version

