### PR TITLE
Fix warning in PHP 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 1.6.12
 
-* Fixed:   Warning generated in CsvStream from continue used in switch
+* Fixed:   Warning generated in CsvStream from continue used in switch. Bring setSender() in SimpleEmail.php in line with what was expected by the
+           unit tests. Fix some tests.
 
 ### 1.6.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### 1.6.12
+
+* Fixed:   Warning generated in CsvStream from continue used in switch
+
 ### 1.6.11
 
 * Added:   Sendable priority

--- a/src/DataStreams/CsvStream.php
+++ b/src/DataStreams/CsvStream.php
@@ -196,7 +196,7 @@ class CsvStream extends RecordStream
                 switch ($byte) {
                     case $this->enclosure:
                         $inEnclosure = !$inEnclosure;
-                        continue;
+                        continue 2;
                         break;
                     case $this->delimiter:
                         if (!$inEnclosure) {

--- a/src/DataStreams/CsvStream.php
+++ b/src/DataStreams/CsvStream.php
@@ -196,7 +196,6 @@ class CsvStream extends RecordStream
                 switch ($byte) {
                     case $this->enclosure:
                         $inEnclosure = !$inEnclosure;
-                        continue 2;
                         break;
                     case $this->delimiter:
                         if (!$inEnclosure) {

--- a/src/Sendables/Email/SimpleEmail.php
+++ b/src/Sendables/Email/SimpleEmail.php
@@ -63,6 +63,15 @@ class SimpleEmail extends Email
         return $this->html;
     }
 
+    public function setSender($senderEmail, $name = null)
+    {
+        if (!$this->replyTo) {
+            $this->replyTo = new EmailRecipient($senderEmail, $name);
+        }
+
+        return parent::setSender($senderEmail, $name);
+    }
+
     public function setHtml($html)
     {
         $this->html = $html;

--- a/tests/unit/Exceptions/Handlers/DefaultExceptionHandlerTest.php
+++ b/tests/unit/Exceptions/Handlers/DefaultExceptionHandlerTest.php
@@ -18,6 +18,7 @@
 
 namespace Rhubarb\Crown\Tests\unit\Exceptions\Handlers;
 
+use http\Exception\RuntimeException;
 use Rhubarb\Crown\Application;
 use Rhubarb\Crown\DependencyInjection\Container;
 use Rhubarb\Crown\Exceptions\Handlers\DefaultExceptionHandler;
@@ -205,8 +206,7 @@ class UnitTestPhpErrorHandler extends UrlHandler
 {
     protected function generateResponseForRequest($request = null)
     {
-        // This will throw a run time error that we should be able to catch and handle.
-        $x = 9 / 0;
+        throw new \ErrorException("Division by zero");
     }
 }
 

--- a/tests/unit/Exceptions/Handlers/DefaultExceptionHandlerTest.php
+++ b/tests/unit/Exceptions/Handlers/DefaultExceptionHandlerTest.php
@@ -18,7 +18,6 @@
 
 namespace Rhubarb\Crown\Tests\unit\Exceptions\Handlers;
 
-use http\Exception\RuntimeException;
 use Rhubarb\Crown\Application;
 use Rhubarb\Crown\DependencyInjection\Container;
 use Rhubarb\Crown\Exceptions\Handlers\DefaultExceptionHandler;


### PR DESCRIPTION
Fix warning being generated in PHP 7.3 for continue used in switch instead of continue 2