### PR TITLE
On URL fragment matching before and after functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### 1.6.13
+
+* Added:   Added functions onBeforeUrlFragmentMatched() and onAfterUrlFragmentMatched() to allow an opportunity to add custom
+           logic before a matching URL is found from a URL Handler
+
 ### 1.6.12
 
 * Updated:  Composer update for latest dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### 1.6.13
 
-* Added:   Added functions onBeforeUrlFragmentMatched() and onAfterUrlFragmentMatched() to allow an opportunity to add custom
-           logic before a matching URL is found from a URL Handler
+* Added:   Added function onUrlFragmentMatched() to offer and opportunity to augment behaviour of the URL Handler
 
 ### 1.6.12
 

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -296,7 +296,11 @@ abstract class UrlHandler implements GeneratesResponseInterface
         $context = new PhpContext();
         $context->UrlHandler = $this;
 
+        $this->onBeforeUrlFragmentMatched($request, $currentUrlFragment);
+
         $this->matchingUrl = $this->getMatchingUrlFragment($request, $currentUrlFragment);
+
+        $this->onAfterUrlFragmentMatched($request, $currentUrlFragment);
 
         if ($this->parentHandler) {
             $this->handledUrl = $this->parentHandler->handledUrl . $this->matchingUrl;
@@ -363,6 +367,28 @@ abstract class UrlHandler implements GeneratesResponseInterface
         }
 
         return false;
+    }
+
+    /**
+     * Opportunity to add additional logic before getMatchingUrlFragment is executed
+     *
+     * @param Request $request
+     * @param string $currentUrlFragment
+     */
+    protected function onBeforeUrlFragmentMatched(Request $request, $currentUrlFragment = "")
+    {
+
+    }
+
+    /**
+     * Opportunity to add additional logic after getMatchingUrlFragment is executed
+     *
+     * @param Request $request
+     * @param string $currentUrlFragment
+     */
+    protected function onAfterUrlFragmentMatched(Request $request, $currentUrlFragment = "")
+    {
+
     }
 
     /**

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -296,11 +296,7 @@ abstract class UrlHandler implements GeneratesResponseInterface
         $context = new PhpContext();
         $context->UrlHandler = $this;
 
-        $this->onBeforeUrlFragmentMatched($request, $currentUrlFragment);
-
         $this->matchingUrl = $this->getMatchingUrlFragment($request, $currentUrlFragment);
-
-        $this->onAfterUrlFragmentMatched($request, $currentUrlFragment);
 
         if ($this->parentHandler) {
             $this->handledUrl = $this->parentHandler->handledUrl . $this->matchingUrl;
@@ -363,6 +359,8 @@ abstract class UrlHandler implements GeneratesResponseInterface
         }
 
         if (stripos($currentUrlFragment, $this->url) === 0) {
+            $this->onUrlFragmentMatched($request, $currentUrlFragment);
+
             return $this->url;
         }
 
@@ -370,23 +368,12 @@ abstract class UrlHandler implements GeneratesResponseInterface
     }
 
     /**
-     * Opportunity to add additional logic before getMatchingUrlFragment is executed
+     * Opportunity to add additional logic if the URL fragment is matched
      *
      * @param Request $request
      * @param string $currentUrlFragment
      */
-    protected function onBeforeUrlFragmentMatched(Request $request, $currentUrlFragment = "")
-    {
-
-    }
-
-    /**
-     * Opportunity to add additional logic after getMatchingUrlFragment is executed
-     *
-     * @param Request $request
-     * @param string $currentUrlFragment
-     */
-    protected function onAfterUrlFragmentMatched(Request $request, $currentUrlFragment = "")
+    protected function onUrlFragmentMatched(Request $request, $currentUrlFragment = "")
     {
 
     }


### PR DESCRIPTION
Added functions onBeforeUrlFragmentMatched() and onAfterUrlFragmentMatched() to allow an opportunity to add custom logic before a matching URL is found from a URL Handler