### PR TITLE
Allow customisation of Content-Type email header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### 1.7.3
+
+* Added: Function getContentType() in Email.php to allow customisation of the Content-Type email header.
+
+
 ### 1.7.2
 
 * Added:  Reversed type hinting to Container.php to match interface - PSR package wasn't 

--- a/src/Sendables/Email/Email.php
+++ b/src/Sendables/Email/Email.php
@@ -182,6 +182,8 @@ abstract class Email extends Sendable
         $text = $this->getText();
         $subject = $this->getSubject();
 
+        $contentType = $this->getContentType();
+
         /**
          * @var string|bool Tracks which part should contain the text and html parts.
          */
@@ -203,6 +205,11 @@ abstract class Email extends Sendable
 
         if ($html != "") {
             $htmlPart = new MimePartText("text/html");
+
+            if($contentType != ""){
+                $htmlPart->addHeader("Content-Type", $contentType);
+            }
+
             $htmlPart->setTransformedBody($html);
         }
 
@@ -236,6 +243,15 @@ abstract class Email extends Sendable
         $mime->addHeader("Reply-To", $this->getReplyToRecipient());
 
         return $mime;
+    }
+
+    /**
+     * Returns a string value which will set the Content-Type header for the html part of the email.
+     *
+     * @return string
+     */
+    protected function getContentType(){
+        return "";
     }
 
     public function getBodyRaw()


### PR DESCRIPTION
Added the function getContentType() in Email.php to allow customisation of the Content-Type email header.