### PR TITLE
Fix fatal error when trying to use sizeof() on a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### 1.7.4
+
+* Fixed: Fatal error when trying to use sizeof() function on a string value in PhpLog.php.
+
 ### 1.7.3
 
 * Added: Function getContentType() in Email.php to allow customisation of the Content-Type email header.

--- a/src/Logging/PhpLog.php
+++ b/src/Logging/PhpLog.php
@@ -40,7 +40,7 @@ class PhpLog extends IndentedMessageLog
         $ip = self::getRemoteIP();
         $category = ($category == "") ? "CORE" : $category;
 
-        $data = sizeof($additionalData) > 0 ? print_r($additionalData, true) : "";
+        $data = $additionalData ? print_r($additionalData, true) : "";
 
         error_log(str_pad($category, 8, ' ', STR_PAD_RIGHT) .
             str_pad($this->uniqueIdentifier, 14, ' ', STR_PAD_LEFT) .


### PR DESCRIPTION
Trying to use sizeof() function on $additionalData when it's value is a string was causing a fatal error.