### PR TITLE
Make sorting php8 compatible

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -249,10 +249,10 @@ class Application extends Module
             $bPriority = $b->getPriority();
 
             if ($aPriority == $bPriority) {
-                return ($a->getCreationOrder() > $b->getCreationOrder());
+                return ($a->getCreationOrder() - $b->getCreationOrder());
             }
 
-            return ($aPriority <= $bPriority);
+            return ($aPriority - $bPriority);
         });
 
         return $filteredHandlers;


### PR DESCRIPTION
uasort() requires an integer output from it's callback function in php8 