### PR TITLE
Security Update: Allow samesite attribute to be set on cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### 1.7.9
+
+* Updated: setCookie() function in HttpResponse.php to allow for the SameSite attribute to be set with new php 
+           setcookie() options array method signature. 
+
 ### 1.7.8
 
 * Updated: Requests containing URL parameters are now sanitised to prevent XSS attacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### 1.7.8
+
+* Updated: Requests containing URL parameters are now sanitised to prevent XSS attacks
+
 ### 1.7.7
 * Fixed: More deprecated required parameter follows optional parameter warnings
 

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -94,10 +94,11 @@ class HttpResponse
      * @param string $domain Domain the cookie should be available to - defaults to current subdomain. Set to ".domain.com" to make available to all subdomains.
      * @param bool $secure Indicates that the cookie should only be transmitted via HTTPS - defaults to false
      * @param bool $httpOnly Indicates that the cookie should only be transmitted via the HTTP Protocol - defaults to false
+     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "None".
      */
-    public static function unsetCookie($name, $path = "/", $domain = null, $secure = false, $httpOnly = false)
+    public static function unsetCookie($name, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "None")
     {
-        self::setCookie($name, null, -1000, $path, $domain, $secure, $httpOnly);
+        self::setCookie($name, null, -1000, $path, $domain, $secure, $httpOnly, $sameSite);
     }
 
     /**

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -63,9 +63,9 @@ class HttpResponse
      * @param string $domain Domain the cookie should be available to - defaults to current subdomain. Set to ".domain.com" to make available to all subdomains.
      * @param bool $secure Indicates that the cookie should only be transmitted via HTTPS - defaults to false
      * @param bool $httpOnly Indicates that the cookie should only be transmitted via the HTTP Protocol - defaults to false
-     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "None".
+     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "Lax".
      */
-    public static function setCookie($name, $value, $expirySecondsFromNow = 1209600, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "None")
+    public static function setCookie($name, $value, $expirySecondsFromNow = 1209600, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "Lax")
     {
         if ($expirySecondsFromNow != null){
             $expirySecondsFromNow = time() + $expirySecondsFromNow;
@@ -94,9 +94,9 @@ class HttpResponse
      * @param string $domain Domain the cookie should be available to - defaults to current subdomain. Set to ".domain.com" to make available to all subdomains.
      * @param bool $secure Indicates that the cookie should only be transmitted via HTTPS - defaults to false
      * @param bool $httpOnly Indicates that the cookie should only be transmitted via the HTTP Protocol - defaults to false
-     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "None".
+     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "Lax".
      */
-    public static function unsetCookie($name, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "None")
+    public static function unsetCookie($name, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "Lax")
     {
         self::setCookie($name, null, -1000, $path, $domain, $secure, $httpOnly, $sameSite);
     }

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -63,8 +63,9 @@ class HttpResponse
      * @param string $domain Domain the cookie should be available to - defaults to current subdomain. Set to ".domain.com" to make available to all subdomains.
      * @param bool $secure Indicates that the cookie should only be transmitted via HTTPS - defaults to false
      * @param bool $httpOnly Indicates that the cookie should only be transmitted via the HTTP Protocol - defaults to false
+     * @param string $sameSite Indicates the SameSite attribute of the cookie. Can be "Strict", "Lax" or "None" - defaults to "None".
      */
-    public static function setCookie($name, $value, $expirySecondsFromNow = 1209600, $path = "/", $domain = null, $secure = false, $httpOnly = false)
+    public static function setCookie($name, $value, $expirySecondsFromNow = 1209600, $path = "/", $domain = null, $secure = false, $httpOnly = false, $sameSite = "None")
     {
         if ($expirySecondsFromNow != null){
             $expirySecondsFromNow = time() + $expirySecondsFromNow;
@@ -73,7 +74,14 @@ class HttpResponse
         }
 
         if (!Application::current()->unitTesting) {
-            setcookie($name, $value, $expirySecondsFromNow, $path, $domain, $secure, $httpOnly);
+            setcookie($name, $value, [
+                'expires' => $expirySecondsFromNow,
+                'path' => $path,
+                'domain' => $domain,
+                'secure' => $secure,
+                'httponly' => $httpOnly,
+                'samesite' => $sameSite
+            ]);
         }
 
         $request = Request::current();

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -266,6 +266,17 @@ abstract class UrlHandler implements GeneratesResponseInterface
         return $request->server("REQUEST_SCHEME") . "://" . $request->server("SERVER_NAME") . $this->handledUrl;
     }
 
+    private function sanitizeRequest($request) {
+        foreach ($request as $key => $value) {
+            if (is_string($value)) {
+                $request->$key = filter_var($value, FILTER_SANITIZE_STRING);
+            } elseif (is_array($value)) {
+                $request->$key = filter_var_array($value, FILTER_SANITIZE_STRING);
+            }
+        }
+        return $request;
+    }
+
     /**
      * Return the response when appropriate or false if no response could be generated.
      *
@@ -277,6 +288,10 @@ abstract class UrlHandler implements GeneratesResponseInterface
      */
     public function generateResponse($request = null, $currentUrlFragment = false)
     {
+        if ($request !== null) {
+            $request = $this->sanitizeRequest($request);
+        }
+
         if ($currentUrlFragment === false) {
             $currentUrlFragment = $request->urlPath;
         }

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -267,13 +267,7 @@ abstract class UrlHandler implements GeneratesResponseInterface
     }
 
     private function sanitizeRequest($request) {
-        foreach ($request as $key => $value) {
-            if (is_string($value)) {
-                $request->$key = filter_var($value, FILTER_SANITIZE_STRING);
-            } elseif (is_array($value)) {
-                $request->$key = filter_var_array($value, FILTER_SANITIZE_STRING);
-            }
-        }
+        $request->urlPath = htmlspecialchars($request->urlPath);
         return $request;
     }
 

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -267,7 +267,7 @@ abstract class UrlHandler implements GeneratesResponseInterface
     }
 
     private function sanitizeRequest($request) {
-        $request->urlPath = htmlspecialchars($request->urlPath);
+        $request->uri = htmlspecialchars($request->uri);
         return $request;
     }
 


### PR DESCRIPTION
Updated rhubarb SetCookie function to use different method signature for PHP setcookie which allows you to set the samesite attribute in an array of options.

https://www.php.net/manual/en/function.setcookie.php