### PR TITLE
Fix fatal errors from strict method signatures

### DIFF
--- a/src/Assets/AssetUrlHandler.php
+++ b/src/Assets/AssetUrlHandler.php
@@ -76,12 +76,13 @@ class AssetUrlHandler extends UrlHandler
     /**
      * Return the response if appropriate or false if no response could be generated.
      *
-     * @param mixed $request
+     * @param null $request
+     * @param string $currentUrlFragment
      * @return bool|Response
      * @throws AssetExposureException
      * @throws StopGeneratingResponseException
      */
-    protected function generateResponseForRequest($request = null)
+    protected function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         try {
             if (!$this->isPermitted()) {

--- a/src/UrlHandlers/CallableUrlHandler.php
+++ b/src/UrlHandlers/CallableUrlHandler.php
@@ -44,9 +44,13 @@ class CallableUrlHandler extends UrlHandler
      * @param mixed $request
      * @return bool|Response
      */
-    protected function generateResponseForRequest($request = null)
+    protected function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         $generator = $this->createGenerator();
+
+        if ($generator === false) {
+            return false;
+        }
 
         if ($generator instanceof Response){
             return $generator;

--- a/src/UrlHandlers/ClassMappedUrlHandler.php
+++ b/src/UrlHandlers/ClassMappedUrlHandler.php
@@ -46,7 +46,7 @@ class ClassMappedUrlHandler extends UrlHandler
         return $object;
     }
 
-    public function generateResponseForRequest($request = null)
+    public function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         $object = $this->createHandlingClass();
 

--- a/src/UrlHandlers/GreedyUrlHandler.php
+++ b/src/UrlHandlers/GreedyUrlHandler.php
@@ -83,7 +83,7 @@ class GreedyUrlHandler extends CallableUrlHandler
         return $generator;
     }
 
-    protected function generateResponseForRequest($request = null)
+    protected function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         if (!$this->matched){
             return false;

--- a/src/UrlHandlers/StaticResourceUrlHandler.php
+++ b/src/UrlHandlers/StaticResourceUrlHandler.php
@@ -52,7 +52,7 @@ class StaticResourceUrlHandler extends UrlHandler
         }
     }
 
-    protected function generateResponseForRequest($request = false)
+    protected function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         if ($this->staticFile !== false) {
             $response = new Response();

--- a/src/UrlHandlers/UrlCapturedDataUrlHandler.php
+++ b/src/UrlHandlers/UrlCapturedDataUrlHandler.php
@@ -24,7 +24,7 @@ class UrlCapturedDataUrlHandler extends ClassMappedUrlHandler
 {
     private $capturedData = null;
 
-    public function generateResponseForRequest($request = null)
+    public function generateResponseForRequest($request = null, $currentUrlFragment = "")
     {
         $object = $this->createHandlingClass();
 

--- a/src/UrlHandlers/UrlHandler.php
+++ b/src/UrlHandlers/UrlHandler.php
@@ -242,7 +242,7 @@ abstract class UrlHandler implements GeneratesResponseInterface
      * @param mixed $request
      * @return bool|Response
      */
-    abstract protected function generateResponseForRequest($request = null);
+    abstract protected function generateResponseForRequest($request = null, $currentUrlFragment = "");
 
     /**
      * Takes a URL fragment understood by a child handler and adds back the parents URL fragment to form a complete URL.


### PR DESCRIPTION
- PHP8 enforces strict method signature rules which result in fatal errors.
- https://php.watch/versions/8.0/lsp-errors
- Updates generateResponseForRequest with the $currentUrlFragment parameter as it is being called with this parameter in generateResponse.
- Also updates functions which implement the abstract method from UrlHandler.php generateResponseForRequest.